### PR TITLE
[Fixes #4] Errors thrown from onCancel() are swallowed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,27 @@ Install:
 npm install --save speculation
 ```
 
-Use:
+### What is a Speculation?
+
+A speculation is exactly like a promise, except for these changes:
+
+* Speculations can be easily cancelled. Simply pass a `shouldCancel` promise into the speculation during creation.
+* `new` is not required when creating a speculation. (That would be extra typing for no benefit).
+
+The signature is:
+
+```js
+speculation(fn: PromiseFunction, shouldCancel: Promise) => Promise
+
+// Similar to the function passed into the Promise constructor.
+// A function to pass into speculation() which
+// performs promise setup, resolve, reject, and cleanup.
+PromiseFunction(resolve: Function, reject: Function, handleCancel: Function) => Void
+```
+
+As you can see from the signature, **speculations are promises**, meaning they share exactly the same promise interface. Anything that understands promises can use speculations instead. There are no extra properties on speculation objects.
+
+### Example: Cancellable wait()
 
 Let's use it to create a cancellable `wait()` function. It'll take `time` in ms, and a promise to use as `shouldCancel`. When the time runs out, the promise will resolve. If the wait is cancelled, the returned promise will reject with a 'Cancelled' error.
 
@@ -48,26 +68,6 @@ wait(200, wait(50)).then(
   (e) => console.log(e)
 ); // [Error: Cancelled]
 ```
-
-## What is a Speculation?
-
-A speculation is exactly like a promise, except for these changes:
-
-* Speculations can be easily cancelled. Simply pass a `shouldCancel` promise into the speculation during creation.
-* `new` is not required when creating a speculation. (That would be extra typing for no benefit).
-
-The signature is:
-
-```js
-speculation(fn: PromiseFunction, shouldCancel: Promise) => Promise
-
-// Similar to the function passed into the Promise constructor.
-// A function to pass into speculation() which
-// performs promise setup, resolve, reject, and cleanup.
-PromiseFunction(resolve: Function, reject: Function, handleCancel: Function) => Void
-```
-
-As you can see from the signature, **speculations are promises**, meaning they share exactly the same promise interface. Anything that understands promises can use speculations instead. There are no extra properties on speculation objects.
 
 
 ## Why?
@@ -105,7 +105,10 @@ const speculation = (
 
   const handleCancel = (
     onCancel
-  ) => cancel.then(onCancel, noop);
+  ) => cancel.then(onCancel, noop)
+    // handle onCancel errors
+    .catch(e => reject(e))
+  ;
 
   fn(resolve, reject, handleCancel);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 var speculation = function speculation (fn) {
+  // Don't cancel by default:
   var cancel = (
     arguments.length > 1 &&
     arguments[1] !== undefined
@@ -10,8 +11,11 @@ var speculation = function speculation (fn) {
     var handleCancel = function handleCancel (onCancel) {
       return cancel.then(
         onCancel,
+        // Filter out the expected "not cancelled" rejection:
         noop
       ).catch(function (e) {
+        // Reject the speculation if there's a an error in
+        // onCancel:
         return reject(e);
       });
     };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,19 @@
-var speculation = function speculation (fn, cancel) {
+var speculation = function speculation (fn) {
+  var cancel = (
+    arguments.length > 1 &&
+    arguments[1] !== undefined
+  ) ? arguments[1] : Promise.reject('Cancelled');
+
   return new Promise(function (resolve, reject) {
     var noop = function noop () {};
 
     var handleCancel = function handleCancel (onCancel) {
-      return cancel.then(onCancel, noop);
+      return cancel.then(
+        onCancel,
+        noop
+      ).catch(function (e) {
+        return reject(e);
+      });
     };
 
     return fn(resolve, reject, handleCancel);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ var speculation = function speculation (fn) {
   var cancel = (
     arguments.length > 1 &&
     arguments[1] !== undefined
-  ) ? arguments[1] : Promise.reject('Cancelled');
+  ) ? arguments[1] : Promise.reject();
 
   return new Promise(function (resolve, reject) {
     var noop = function noop () {};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -41,3 +41,24 @@ test('speculation cancelled on time', assert => {
     }
   );
 });
+
+test('speculation that throws in onCancel', assert => {
+  const msg = 'should handle onCancel error';
+
+  const faultyWait = (
+    time,
+    cancel = Promise.resolve()
+  ) => speculation((resolve, reject, onCancel) => {
+    onCancel(() => {
+      throw new Error('Oops!');
+    });
+  }, cancel);
+
+  faultyWait(30).catch(e => {
+    const actual = e.message;
+    const expected = 'Oops!';
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
+});


### PR DESCRIPTION
Handle the normal cancel error with a noop and then catch the success handler's error with `.catch()`:

```js
const speculation = (
  fn, cancel = Promise.reject('Cancelled')
) => new Promise((resolve, reject) => {
  const noop = () => {};

  const handleCancel = (
    onCancel
  ) => cancel.then(
    onCancel,
    noop
  ).catch(e => reject(e));

  return fn(resolve, reject, handleCancel);
});
```