### PR TITLE
Prevent onCancel race conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/ericelliott/speculation#readme",
   "devDependencies": {
     "eslint": "3.14.0",
+    "sinon": "^1.17.7",
     "tape": "4.6.3",
     "updtr": "0.2.3",
     "watch": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/ericelliott/speculation#readme",
   "devDependencies": {
     "eslint": "3.14.0",
-    "sinon": "^1.17.7",
     "tape": "4.6.3",
     "updtr": "0.2.3",
     "watch": "1.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,13 @@ var speculation = function speculation (fn) {
     var isFulfilled = false;
 
     // When the callsite resolves, mark the promise as fulfilled.
-    var resolve = function resolver (input) {
+    var resolve = function resolve (input) {
       isFulfilled = true;
       _resolve(input);
     };
 
     // When the callsite rejects, mark the promise as fulfilled.
-    var reject = function rejecter (input) {
+    var reject = function reject (input) {
       isFulfilled = true;
       _reject(input);
     };


### PR DESCRIPTION
The goal of this PR is to avoid `onCancel` become called when a Promise does not actually become cancelled.

In Speculation's current form, `onCancel` will become invoked regardless of the outcome of the observed promise. This callback is useful to to perform cleanup tasks, but it might be used to perform other duties that should only be performed when a promise is indeed cancelled early.

This solution will avoid triggering `onCancel` unless the cancellation is actually performed before the pending promise becomes completed.

The solution works by creating a higher order function of `resolve` that lets `speculation` know if the Promise becomes resolved or rejected downstream in where the promise is managed by the dependent's business logic. The higher order function will maintain a `boolean` state of `completed`. Unfortunately this is a bit of an impure approach, as we manage state within `speculation` on the "progress" of the promise -- but I wasn't quite sure off the top of my head of a better way. **Happy to revise if requested.**

Example:

```js
const speculation = require('./src/index');

const wait = (time, cancel) => {
  return speculation((resolve, reject, onCancel) => {
    var timer = setTimeout(resolve, time);

    onCancel(() => {
      console.log('onCancel invoked');
      clearTimeout(timer);
      reject(new Error('Cancelled'));

      // Perhaps report to something upstream in our application that
      // the pending promise has failed to complete properly.
    });
  }, cancel);
}

wait(100, wait(200))
  .then(() => console.log('Our promise has completed'));
```

Example output:
<img width="301" alt="screen shot 2017-01-22 at 10 25 48 pm" src="https://cloud.githubusercontent.com/assets/656630/22190534/c9861e40-e0f1-11e6-8fe2-98f41ab2ab51.png">

With this new patch:
<img width="420" alt="screen shot 2017-01-22 at 10 29 41 pm" src="https://cloud.githubusercontent.com/assets/656630/22190594/48f693da-e0f2-11e6-80fe-156b136c7dd3.png">
