### PR TITLE
Static initialization method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,4 +47,13 @@ var speculation = function speculation (fn) {
   });
 };
 
+// Statically initialize a speculation
+speculation.fromPromise = function (promise, cancel, handleCancel) {
+  return speculation((resolve, reject, onCancel) => {
+    promise.then(resolve);
+    promise.catch(reject);
+    onCancel(handleCancel);
+  }, cancel);
+};
+
 module.exports = speculation;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -84,3 +84,23 @@ test('speculation promise resolved before cancel', assert => {
     assert.end();
   });
 });
+
+test('fromPromise should initialize a speculation', assert => {
+  const msg = 'should reject';
+
+  const testWait = time => new Promise(resolve => setTimeout(resolve, time));
+
+  speculation.fromPromise(
+    testWait(20),
+    testWait(10)
+  ).then(
+    () => {
+      assert.fail(msg);
+      assert.end();
+    },
+    () => {
+      assert.pass(msg);
+      assert.end();
+    }
+  );
+});


### PR DESCRIPTION
This adds support for #9 by introducing `speculation.fromPromise`.

A dependent can compose a `speculation` instance by providing a promise task and a cancellation promise as two arguments, as well as an `onCancel` callback as a final third argument.

This affords the ability to work directly with existing promises and not have to interact with the `Promise` constructor whenever creating a speculation.

```js
const wait = time => new Promise(resolve => setTimeout(resolve, time));

speculation.fromPromise(wait(20), wait(10))
.then(..)
.catch(..)
```

There's two questions I have with this:
1. Does this belong within the promise, or should the dependent be composing these ways to initialize a speculation?
2. Would we prefer a different interface, such as:
  ```js
  speculation.fromPromise(cancellationPromise, onCancelled)(taskPromise)
  ```
I don't see much gain from this, as the `cancellationPromise` may only be used once. So it wouldn't be able to compose more than one usage of the speculation instance.